### PR TITLE
Remove angular-base64.min.js from main section to avoid double insert by grunt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,7 @@
     "name": "angular-base64",
     "version": "2.0.1",
     "main": [
-        "angular-base64.js",
-        "angular-base64.min.js"
+        "angular-base64.js"
     ],
     "ignore": [
         "package.json",


### PR DESCRIPTION
Hi, thanks for the lib, after I've installed it and ran: `grunt bower-install` I got 2 new entries to my index.html

```
    <script src="bower_components/angular-base64/angular-base64.js"></script>
    <script src="bower_components/angular-base64/angular-base64.min.js"></script>
```

This is because there are 2 files declared in the main section of .bower.json if I remove angular-base64.min.js from the config and run  `grunt bower-install` in my index.html I only get `<script src="bower_components/angular-base64/angular-base64.js"></script>`

Many thanks
