### PR TITLE
Make the module usable via npm / browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ bower install angular-base64
 <script src="bower_components/angular-base64/angular-base64.js"></script>
 ```
 
+### NPM
+
+```
+npm i angular-base64
+```
+
 ## Usage
 
 ```javascript
@@ -30,6 +36,20 @@ angular
         
             $scope.encoded = $base64.encode('a string');
             $scope.decoded = $base64.decode('YSBzdHJpbmc=');
+    }]);
+```
+
+### Requiring NPM module when using Browserify
+
+```javascript
+angular
+    .module('myApp', [ require('angular-base64') ])
+    .controller('myController', [
+        '$base64', '$scope',
+        function($base64, $scope) {
+
+        $scope.encoded = $base64.encode('a string');
+        $scope.decoded = $base64.decode('YSBzdHJpbmc=');
     }]);
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 require('angular');
 
 // load the angular-base64 module
-require('angular-base64.js')
+require('./angular-base64.js')
 
 module.exports = 'base64';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+// Should already be required, just here for clarity
+require('angular');
+
+// load the angular-base64 module
+require('angular-base64.js')
+
+module.exports = 'base64';

--- a/package.json
+++ b/package.json
@@ -1,15 +1,32 @@
 {
-    "devDependencies": {
-        "grunt": "",
-        "grunt-cli": "",
-        "grunt-contrib-clean": "",
-        "grunt-contrib-copy": "",
-        "grunt-contrib-jshint": "",
-        "grunt-contrib-watch": "",
-        "grunt-contrib-concat": "",
-        "grunt-contrib-uglify": "",
-        "grunt-notify": "",
-        "grunt-strip": "",
-        "grunt-text-replace": ""
-    }
+  "devDependencies": {
+    "grunt": "",
+    "grunt-cli": "",
+    "grunt-contrib-clean": "",
+    "grunt-contrib-copy": "",
+    "grunt-contrib-jshint": "",
+    "grunt-contrib-watch": "",
+    "grunt-contrib-concat": "",
+    "grunt-contrib-uglify": "",
+    "grunt-notify": "",
+    "grunt-strip": "",
+    "grunt-text-replace": ""
+  },
+  "name": "@lemming/angular-base64",
+  "description": "Encapsulation of Nick Galbreath's base64.js library for AngularJS",
+  "version": "0.0.1",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/joelemmer/angular-base64.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/joelemmer/angular-base64/issues"
+  },
+  "homepage": "https://github.com/joelemmer/angular-base64#readme"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "name": "@lemming/angular-base64",
   "description": "Encapsulation of Nick Galbreath's base64.js library for AngularJS",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-strip": "",
     "grunt-text-replace": ""
   },
-  "name": "@lemming/angular-base64",
+  "name": "@ninjatronic/angular-base64",
   "description": "Encapsulation of Nick Galbreath's base64.js library for AngularJS",
   "version": "0.0.2",
   "main": "index.js",
@@ -21,12 +21,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joelemmer/angular-base64.git"
+    "url": "git+https://github.com/ninjatronic/angular-base64.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/joelemmer/angular-base64/issues"
+    "url": "https://github.com/ninjatronic/angular-base64/issues"
   },
-  "homepage": "https://github.com/joelemmer/angular-base64#readme"
+  "homepage": "https://github.com/ninjatronic/angular-base64#readme"
 }


### PR DESCRIPTION
Hi,

I've just added an index.js file to the package which can make the page available via npm and therefore browserify. Example shown in update to readme.

I just have my cloned version in my private npm repository at the moment, so to make the change work, the module would have to be made publicly available on the npm repository, but I didn't want to do that without your permission.

The package.json could do with updating with your details and version numbers as well. I'm happy to make the updates if you let me know what the details should be.

Thanks
Joe
